### PR TITLE
add collection entity to migraitons

### DIFF
--- a/contentful-migrations/collection.js
+++ b/contentful-migrations/collection.js
@@ -1,0 +1,10 @@
+module.exports = function (migration, context) {
+  const collection = migration
+    .createContentType("collection")
+    .name("Collection entry")
+    .displayField("title");
+
+  collection.createField("title").name("Title").type("Symbol");
+  collection.createField("handle").name("Handle").type("Symbol");
+  collection.createField("medusaId").name("Medusa ID").type("Symbol");
+};

--- a/contentful-migrations/index.js
+++ b/contentful-migrations/index.js
@@ -18,6 +18,10 @@ const migrations = async () => {
   });
   await runMigration({
     ...options,
+    ...{ filePath: `${__dirname}/collection.js` },
+  });
+  await runMigration({
+    ...options,
     ...{ filePath: `${__dirname}/hero.js` },
   });
   await runMigration({

--- a/contentful-migrations/product.js
+++ b/contentful-migrations/product.js
@@ -12,6 +12,16 @@ module.exports = function (migration, context) {
     .name("Thumbnail")
     .type("Link")
     .linkType("Asset");
+  product
+    .createField("collection_entry")
+    .name("Collection")
+    .type("Link")
+    .linkType("Entry")
+    .validations([
+      {
+        linkContentType: ["collection"],
+      },
+    ]);
   product.createField("description").name("Description").type("Text");
   product.createField("options").name("Options").type("Object");
   product.createField("tags").name("Tags").type("Object");


### PR DESCRIPTION
**What**
- update datamodel to reflect `medusa-plugin-contentful` update in [706](https://github.com/medusajs/medusa/pull/706)

**How**
- Add migration for collection 
- Add `collection_entry` field to product

**Why**
- To make getting started with Medusa and Contentful easier, since Medusa now will support Collections in Contentful as well

**Testing** 
- Manual testing
  - Running migrations
  - Testing Collection and Product(creation and update) functionality with the `medusa-plugin-contentful` plugin