### PR TITLE
fix: parameter handling in migration script

### DIFF
--- a/contentful-migrations/index.js
+++ b/contentful-migrations/index.js
@@ -2,6 +2,7 @@
 
 require("dotenv").config();
 
+const path = require("path");
 const { runMigration } = require("contentful-migration");
 
 const options = {
@@ -12,6 +13,17 @@ const options = {
 };
 
 const migrations = async () => {
+  if (process.argv.length >= 3) {
+    const files = process.argv.slice(2);
+    files.map(async (filePath) => {
+      await runMigration({
+        ...options,
+        ...{ filePath: path.join(process.cwd(), filePath) }
+      })
+    })
+
+    return;
+  }
   await runMigration({
     ...options,
     ...{ filePath: `${__dirname}/link.js` },


### PR DESCRIPTION
In the documentation, it's mentioned that the migration script can be invoked to handle single files as the following:

```
npm run migrate:contentful --file contentful-migrations/rich-text.js
```

However, this doesn't work as the script that handles the migration does not care about arguments passed to the command.

This new change will allow us to pass parameters to the script as follows:

```
npm run migrate:contentful contentful-migrations/rich-text.js
```

This can be very helpful when customizing the contentful integration by adding content models. At the moment, I'll change the documentation to include details of creating the migration files separate from the integration. If this gets merged I'll reflect it in the documentation.